### PR TITLE
Upgrade license maven plugin dependency and fix publish setting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,11 +40,11 @@ configurations.implementation.transitive = false
 sourceSets.create("integrationTest")
 
 dependencies {
-    implementation "com.mycila.xmltool:xmltool:3.3"
     // Using implementation instead of groovy, so that it goes into the pom
-    implementation "com.mycila:license-maven-plugin:4.3"
-    implementation "com.mycila:license-maven-plugin-git:4.2.rc3"
-    implementation 'commons-io:commons-io:2.11.0'
+    implementation "com.mycila:license-maven-plugin:4.2"
+    implementation "com.mycila:license-maven-plugin-git:4.2"
+    implementation "org.apache.maven:maven-core:3.9.4"
+    implementation "commons-io:commons-io:2.11.0"
 
     implementation gradleApi()
 

--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,7 @@ gradlePlugin {
             implementationClass = "nl.javadude.gradle.plugins.license.LicensePlugin"
             displayName = "License plugin for Gradle"
             description = "Applies a header to files, typically a license. This plugin supports git based configurations."
-            tags.set(["gradle", "plugin", "license", "git"])
+            tags.set(["license", "git"])
         }
     }
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -10,9 +10,10 @@ repositories {
 configurations.api.transitive = false
 
 dependencies {
-    implementation "com.mycila.xmltool:xmltool:3.3"
-    implementation "com.mycila:license-maven-plugin:4.2.rc3"
-    implementation "com.mycila:license-maven-plugin-git:4.2.rc3"
+    implementation "com.mycila:license-maven-plugin:4.2"
+    implementation "com.mycila:license-maven-plugin-git:4.2"
+    implementation "org.apache.maven:maven-core:3.9.4"
+    implementation "commons-io:commons-io:2.11.0"
     implementation gradleApi()
 }
 


### PR DESCRIPTION
Motivation:
Its transitive dependency had vulnerability

Modifications:
- Upgrade license-gradle-plugin
- Upgrade license-gradle-plugin-git
- Specify dependencies that are not resolved(with 4.2 version, maven-plugin related dependencies were not downloaded automatically)
- Remove unnecessary dependency

Result:
- No transitive dependency warning shown.