### PR TITLE
Resolve document type mismatch

### DIFF
--- a/src/main/groovy/nl/javadude/gradle/plugins/license/License.groovy
+++ b/src/main/groovy/nl/javadude/gradle/plugins/license/License.groovy
@@ -199,15 +199,9 @@ class License extends SourceTask implements VerificationTask {
         Map<String, String> combinedMappings = new HashMap<String, String>()
         if (isUseDefaultMappings()) {
             // Sprinkle in some other well known types, which maven-license-plugin doesn't have
-            combinedMappings.put('gradle', 'JAVADOC_STYLE')
-            combinedMappings.put('json', 'JAVADOC_STYLE')
-            combinedMappings.put('scala', 'JAVADOC_STYLE')
             combinedMappings.put('g4', 'JAVADOC_STYLE')
             combinedMappings.put('gsp', 'DYNASCRIPT_STYLE')
-            combinedMappings.put('groovy', 'SLASHSTAR_STYLE')
             combinedMappings.put('clj', 'SEMICOLON_STYLE')
-            combinedMappings.put('yaml', 'SCRIPT_STYLE')
-            combinedMappings.put('yml', 'SCRIPT_STYLE')
         }
         if (getInheritedMappings() != null) {
             combinedMappings.putAll(getInheritedMappings())


### PR DESCRIPTION
Motivation:
license-gradle-plugin document type setting does not completely match with license-maven-plugin
https://github.com/mathieucarbou/license-maven-plugin/blob/5299531591c50f95e7520415a73f6e0a22e737d4/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/document/DocumentType.java

Modifications:
- Remove the extensions that are provided by license-maven-plugin
- Remove json file setting since json files do not support any comments

Result:
- *.gsp file would be subject to XML_STYLE instead of DYNASCRIPT_STYLE
- fixes #7